### PR TITLE
Make PropagateExceptions() actually propagate exceptions

### DIFF
--- a/src/Spectre.Console.Extensions.Hosting/Worker/SpectreConsoleWorker.cs
+++ b/src/Spectre.Console.Extensions.Hosting/Worker/SpectreConsoleWorker.cs
@@ -1,98 +1,38 @@
-using System.Threading;
-
 using Microsoft.Extensions.Hosting;
-using Microsoft.Extensions.Hosting.Internal;
-using Microsoft.Extensions.Logging;
-using Microsoft.Extensions.Options;
 
 using Spectre.Console.Cli;
 using Spectre.Console.Extensions.Hosting.Infrastructure;
 
 namespace Spectre.Console.Extensions.Hosting.Worker;
 
-public class SpectreConsoleWorker : IHostedService
+public class SpectreConsoleWorker : BackgroundService
 {
     private readonly ICommandApp _commandApp;
     private readonly IHostApplicationLifetime _hostLifetime;
     private readonly IArgsProvider _argsProvider;
-    private readonly ILogger<SpectreConsoleWorker> _logger;
-    private int _exitCode;
-    private Task? _startupTask;
 
     public SpectreConsoleWorker
     (
-        ILogger<SpectreConsoleWorker> logger,
         ICommandApp commandApp,
         IHostApplicationLifetime hostLifetime,
         IArgsProvider? argsProvider = null
     )
     {
-        _logger = logger;
         _commandApp = commandApp;
         _hostLifetime = hostLifetime;
         _argsProvider = argsProvider ?? new CommandLineArgsProvider();
     }
 
-    public async Task StartAsync(CancellationToken cancellationToken)
-    {
-        _startupTask = WaitAndStartAsync(cancellationToken);
-        // If the task completed synchronously, await it in order to bubble potential cancellation/failure to the caller
-        // Otherwise, return, allowing application startup to complete
-        if (_startupTask.IsCompleted)
-        {
-            await _startupTask.ConfigureAwait(false);
-        }
-    }
-
-    private async Task WaitAndStartAsync(CancellationToken startupCancellationToken)
-    {
-        // Wait until:
-        // 1. The application is started
-        // 2. The application is stopping due to a cancellation request
-
-        using var combinedCancellationSource = CancellationTokenSource.CreateLinkedTokenSource(startupCancellationToken, _hostLifetime.ApplicationStarted);
-        await Task.Delay(Timeout.InfiniteTimeSpan, combinedCancellationSource.Token) // Wait "indefinitely", until startup completes or is aborted
-            .ContinueWith(_ => { }, TaskContinuationOptions.OnlyOnCanceled) // Without an OperationCanceledException on cancellation
-            .ConfigureAwait(false);
-
-        if (startupCancellationToken.IsCancellationRequested)
-        {
-            return;
-        }
-
-        await StartCommandAsync();
-    }
-
-    private async Task StartCommandAsync()
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
     {
         try
         {
             var args = _argsProvider.GetArgs();
-            _exitCode = await _commandApp.RunAsync(args);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogError(ex, "An unexpected error occurred");
-            _exitCode = 1;
+            Environment.ExitCode = await _commandApp.RunAsync(args);
         }
         finally
         {
             _hostLifetime.StopApplication();
         }
-    }
-
-    public async Task StopAsync(CancellationToken cancellationToken)
-    {
-        // Stopped without having been started
-        if (_startupTask is null)
-        {
-            Environment.ExitCode = _exitCode;
-            return;
-        }
-
-        // Wait until any ongoing startup logic has finished or the graceful shutdown period is over
-        await Task.WhenAny(_startupTask, Task.Delay(Timeout.Infinite, cancellationToken)).ConfigureAwait(false);
-
-        Environment.ExitCode = _exitCode;
     }
 }

--- a/src/Tests/Spectre.Console.Extensions.Hosting.Tests/DependencyInjectionTests.cs
+++ b/src/Tests/Spectre.Console.Extensions.Hosting.Tests/DependencyInjectionTests.cs
@@ -88,13 +88,30 @@ public class DependencyInjectionTests
             .UseSpectreConsole(command =>
             {
                 command.AddCommand<TestCommand>("test");
+                command.SetExceptionHandler(_ => 123);
+            })
+            .ConfigureServices((_, collection) => collection.UseSpectreConsoleArgs("test", "-n", "def"))
+            .UseConsoleLifetime()
+            .Build().Run();
+
+        Assert.Equal(123, Environment.ExitCode);
+    }
+
+    [Fact]
+    public void CommandApp_Different_Values_Propagates_Exception()
+    {
+        var run = () => new HostBuilder()
+            .UseSpectreConsole(command =>
+            {
+                command.AddCommand<TestCommand>("test");
                 command.PropagateExceptions();
             })
             .ConfigureServices((_, collection) => collection.UseSpectreConsoleArgs("test", "-n", "def"))
             .UseConsoleLifetime()
             .Build().Run();
 
-        Assert.Equal(1, Environment.ExitCode);
+        var exception = Assert.Throws<InvalidOperationException>(run);
+        Assert.Equal("Name is not abc", exception.Message);
     }
 
     public class TestSettings : CommandSettings


### PR DESCRIPTION
Also, using BackgroundService instead of implementing IHostedService from scratch significantly simplifies the SpectreConsoleWorker implementaiton.